### PR TITLE
Point Berylline keymap to the right location

### DIFF
--- a/config/berylline.keymap
+++ b/config/berylline.keymap
@@ -2,5 +2,5 @@
 // https://github.com/manna-harbour/miryoku
 
 #include "../miryoku/custom_config.h"
-#include "../miryoku/mapping/32/hummingbird.h"
+#include "../miryoku/mapping/30/hummingbird.h"
 #include "../miryoku/miryoku.dtsi"


### PR DESCRIPTION
I forgot to add this change to the previous PR on the beta repo. I probably updated this file after you made the previous commit to fix the Hummingbird