### PR TITLE
point pteron36 build to zmk-config-pteron36

### DIFF
--- a/.github/workflows/outboards/shields/pteron36
+++ b/.github/workflows/outboards/shields/pteron36
@@ -1,7 +1,7 @@
 # Copyright 2021 Manna Harbour
 # https://github.com/manna-harbour/miryoku
 
-outboard_repository=harshitgoel96/zmk
-outboard_ref=pteron36
-outboard_from=app/boards/shields/pteron36
+outboard_repository=harshitgoel96/zmk-config-pteron36
+outboard_ref=master
+outboard_from=config/boards/shields/pteron36
 outboard_to=boards/shields/pteron36


### PR DESCRIPTION
Original config used my fork of zmkfirmware, with a separate branch for pteron36. i have now created a personal zmk-config repo for pteron36 inline with zmk documents. the same config repo should be used for miryoku zmk build system