### PR TITLE
Add SplitKB Aurora keymaps

### DIFF
--- a/.github/workflows/test-all-promicro-shields.yml
+++ b/.github/workflows/test-all-promicro-shields.yml
@@ -68,6 +68,8 @@ jobs:
         "scylla_dmmpcb_left","scylla_dmmpcb_right",
         "sofle_left","sofle_right",
         "sofle_rgb_left","sofle_rgb_right",
+        "splitkb_aurora_corne_left","splitkb_aurora_corne_right",
+        "splitkb_aurora_sweep_left","splitkb_aurora_sweep_right",
         "splitreus62_left","splitreus62_right",
         "tbkmini_left","tbkmini_right",
         "tbkmini_adapterv2_left","tbkmini_adapterv2_right",

--- a/config/splitkb_aurora_corne.keymap
+++ b/config/splitkb_aurora_corne.keymap
@@ -1,0 +1,6 @@
+// Copyright 2022 Manna Harbour
+// https://github.com/manna-harbour/miryoku
+
+#include "../miryoku/custom_config.h"
+#include "../miryoku/mapping/42/corne.h"
+#include "../miryoku/miryoku.dtsi"

--- a/config/splitkb_aurora_sweep.keymap
+++ b/config/splitkb_aurora_sweep.keymap
@@ -1,0 +1,6 @@
+// Copyright 2021 Manna Harbour
+// https://github.com/manna-harbour/miryoku
+
+#include "../miryoku/custom_config.h"
+#include "../miryoku/mapping/34/ferris.h"
+#include "../miryoku/miryoku.dtsi"


### PR DESCRIPTION
Sorry if I'm not going about this the right way. These are for SplitKB's variants of Corne and Sweep. The keyboard names should match ZMK. Sweep [is already committed](https://github.com/zmkfirmware/zmk/tree/main/app/boards/shields/splitkb_aurora_sweep) and a branch for Corne [is in the works](https://github.com/petejohanson/zmk/tree/shields/splitkb_aurora_corne). 