### PR TITLE
Add Luna support

### DIFF
--- a/.github/workflows/outboards/shields/luna
+++ b/.github/workflows/outboards/shields/luna
@@ -1,4 +1,4 @@
-outboard_repository=Apsu/zmk-luna
-outboard_ref=main
+outboard_repository=mindhatch/zmk-config-luna
+outboard_ref=master
 outboard_from=config/boards/shields/luna
 outboard_to=boards/shields/luna

--- a/.github/workflows/outboards/shields/luna
+++ b/.github/workflows/outboards/shields/luna
@@ -1,0 +1,4 @@
+outboard_repository=mindhatch/zmk-config-luna
+outboard_ref=master
+outboard_from=config/boards/shields/luna
+outboard_to=boards/shields/luna

--- a/.github/workflows/outboards/shields/luna
+++ b/.github/workflows/outboards/shields/luna
@@ -1,4 +1,4 @@
-outboard_repository=mattdibi/zmk-config-luna
+outboard_repository=Apsu/zmk-luna
 outboard_ref=master
 outboard_from=config/boards/shields/luna
 outboard_to=boards/shields/luna

--- a/.github/workflows/outboards/shields/luna
+++ b/.github/workflows/outboards/shields/luna
@@ -1,3 +1,6 @@
+# Copyright 2022 Manna Harbour
+# https://github.com/manna-harbour/miryoku
+
 outboard_repository=mindhatch/zmk-config-luna
 outboard_ref=master
 outboard_from=config/boards/shields/luna

--- a/.github/workflows/outboards/shields/luna
+++ b/.github/workflows/outboards/shields/luna
@@ -1,4 +1,4 @@
 outboard_repository=Apsu/zmk-luna
-outboard_ref=master
+outboard_ref=main
 outboard_from=config/boards/shields/luna
 outboard_to=boards/shields/luna

--- a/.github/workflows/outboards/shields/luna
+++ b/.github/workflows/outboards/shields/luna
@@ -1,4 +1,4 @@
-outboard_repository=mindhatch/zmk-config-luna
+outboard_repository=mattdibi/zmk-config-luna
 outboard_ref=master
 outboard_from=config/boards/shields/luna
 outboard_to=boards/shields/luna

--- a/.github/workflows/test-all-promicro-shields.yml
+++ b/.github/workflows/test-all-promicro-shields.yml
@@ -51,6 +51,7 @@ jobs:
         "levinson_left","levinson_right",
         "lily58_left","lily58_right",
         "lotus58_left","lotus58_right",
+        "luna_left","luna_right",
         "mano42_left","mano42_right",
         "microdox_left","microdox_right",
         "microdox_mod_left","microdox_mod_right",

--- a/config/luna.conf
+++ b/config/luna.conf
@@ -1,0 +1,4 @@
+# Copyright 2022 Manna Harbour
+# https://github.com/manna-harbour/miryoku
+
+CONFIG_ZMK_COMBO_MAX_COMBOS_PER_KEY=16

--- a/config/luna.keymap
+++ b/config/luna.keymap
@@ -1,0 +1,3 @@
+#include "../miryoku/custom_config.h"
+#include "../miryoku/mapping/30/hummingbird.h"
+#include "../miryoku/miryoku.dtsi"

--- a/config/luna.keymap
+++ b/config/luna.keymap
@@ -1,3 +1,6 @@
+// Copyright 2022 Manna Harbour
+// https://github.com/manna-harbour/miryoku
+
 #include "../miryoku/custom_config.h"
 #include "../miryoku/mapping/30/hummingbird.h"
 #include "../miryoku/miryoku.dtsi"

--- a/miryoku/miryoku_kludge_bottomrowcombos.dtsi
+++ b/miryoku/miryoku_kludge_bottomrowcombos.dtsi
@@ -1,7 +1,7 @@
 // Copyright 2022 Manna Harbour
 // https://github.com/manna-harbour/miryoku
 
-#define MIRYOKU_KLUDGE_BOTTOMROWCOMBOS_TERM 200
+#define MIRYOKU_KLUDGE_BOTTOMROWCOMBOS_TERM 50
 #define MIRYOKU_KLUDGE_BOTTOMROWCOMBOS_MACRO(LAYER, POSITION, BINDING) \
 bottomrowcombos_ ## LAYER ## _ ## POSITION { \
   layers = <LAYER>; \

--- a/miryoku/miryoku_kludge_bottomrowcombos.dtsi
+++ b/miryoku/miryoku_kludge_bottomrowcombos.dtsi
@@ -1,7 +1,7 @@
 // Copyright 2022 Manna Harbour
 // https://github.com/manna-harbour/miryoku
 
-#define MIRYOKU_KLUDGE_BOTTOMROWCOMBOS_TERM 50
+#define MIRYOKU_KLUDGE_BOTTOMROWCOMBOS_TERM 200
 #define MIRYOKU_KLUDGE_BOTTOMROWCOMBOS_MACRO(LAYER, POSITION, BINDING) \
 bottomrowcombos_ ## LAYER ## _ ## POSITION { \
   layers = <LAYER>; \


### PR DESCRIPTION
As discussed in https://github.com/manna-harbour/miryoku/discussions/183 this PR add support for the [Luna keyboard by Mindhatch](https://kbd.news/Luna-keyboard-1820.html).

Additional informations:
- Luna keyboard PCB repository: https://github.com/mindhatch/keyboards
- Luna keyboard firmware repository: https://github.com/mindhatch/zmk-config-luna

Luna is a 30 key keyboard and uses the same keymap as the Hummingbird (i.e. bottom row combos + thumb combos enabled by default).