### PR TITLE
update outboard directory for temper

### DIFF
--- a/.github/workflows/outboards/shields/temper
+++ b/.github/workflows/outboards/shields/temper
@@ -3,5 +3,5 @@
 
 outboard_repository=raeedcho/temper-zmk-config
 outboard_ref=main
-outboard_from=config/boards/shields/temper
+outboard_from=boards/shields/temper
 outboard_to=boards/shields/temper


### PR DESCRIPTION
The reference 'outboard_from' was moved on the outboard repository. This PR fixes the outboard ref and allows it to build.