### PR TITLE
readme.org - ZMK Docker Build Subsection

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -42,6 +42,13 @@ First [[https://zmk.dev/docs/development/setup][set up the ZMK build environment
 Clone this repository and set [[https://zmk.dev/docs/development/build-flash#building-from-zmk-config-folder][ZMK_CONFIG]] to the absolute path of the [[config]] subdirectory.  Use the [[#config-file][config file]] to select alternative layout and mapping options.
 
 
+**** Docker Builds
+If using the [[https://zmk.dev/docs/development/setup/docker][ZMK Docker build environment]], create your [[https://zmk.dev/docs/development/build-flash#building-from-zmk-config-folder][zmk-config volume]] with the ~device~ argument set to the absolute path of your ~miryoku_zmk~ directory. [[https://github.com/manna-harbour/miryoku_zmk][Miryoku ZMK]] must be in the ~zmk-config~ volume in order for your keymap to build.
+
+The [[config]] subdirectory can then be provided at build time.
+: -DZMK_CONFIG="/workspaces/zmk-config/config"
+
+
 *** Workflow Builds
 
 Firmware can be built via GitHub Actions workflows without use of a local build environment.


### PR DESCRIPTION
## Issue
The `Local Build` section of `readme.org` specifies that `ZMK_CONFIG` be set to the absolute path of the [config](https://github.com/manna-harbour/miryoku_zmk/tree/master/config) directory.

When using the local docker build environment, following these instructions would lead the user to create their `zmk-config` [docker volume with a device path](https://zmk.dev/docs/development/build-flash#building-from-zmk-config-folder) set to [config](https://github.com/manna-harbour/miryoku_zmk/tree/master/config).

Doing so will exclude the Miryoku code from the volume, and any build will fail.

### Failing Build
With `miryoku_zmk/config` provided as the device path.

```
docker volume create --driver local -o o=bind -o type=none -o device="/var/code/miryoku_zmk/config" zmk-config 

west build -p -d build/right -b nice_nano_v2 -- -DSHIELD=corne_right -DZMK_CONFIG="/workspaces/zmk-config/"
```

<img width="966" alt="image" src="https://github.com/user-attachments/assets/87a9386a-53b8-4ff2-b79d-824f775584bb">

## Resolution 
Adding subsection to the local build documentation to inform those using the docker build environment of this, and give instructions on the correct path.

### Successful Build
With `miryoku_zmk` provided as the device path.
```
docker volume create --driver local -o o=bind -o type=none -o device="/var/code/miryoku_zmk/" zmk-config 

west build -p -d build/right -b nice_nano_v2 -- -DSHIELD=corne_right -DZMK_CONFIG="/workspaces/zmk-config/config"
```

<img width="696" alt="image" src="https://github.com/user-attachments/assets/60fc41b3-d6ad-4b36-bf9b-afacdfd3cab0">

----
Let me know if there is any issue with this, or if you would like it phrased differently.