### PR TITLE
adds support for dongles

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,7 +92,7 @@ jobs:
           fi
           echo "shield_arg=$SHIELD_ARG" >> $GITHUB_OUTPUT
           keyboard_split="$keyboard"
-          keyboard_base=`echo "$keyboard" | sed -e 's/_\(left\|right\|dongle\|central\)//' -e 's/@.*//'`
+          keyboard_base=`echo "$keyboard" | sed -e 's/_\(left\|right\|dongle\)//' -e 's/@.*//'`
 
           configfile="${GITHUB_WORKSPACE}/miryoku_zmk/miryoku/custom_config.h"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,7 +92,7 @@ jobs:
           fi
           echo "shield_arg=$SHIELD_ARG" >> $GITHUB_OUTPUT
           keyboard_split="$keyboard"
-          keyboard_base=`echo "$keyboard" | sed -e 's/_\(left\|right\)//' -e 's/@.*//'`
+          keyboard_base=`echo "$keyboard" | sed -e 's/_\(left\|right\|dongle\|central\)//' -e 's/@.*//'`
 
           configfile="${GITHUB_WORKSPACE}/miryoku_zmk/miryoku/custom_config.h"
 


### PR DESCRIPTION
Currently there is a code check for splitting firmware into left and right halves, this code change implements also splitting by _dongle or _central suffix