### PR TITLE
fix(outboards): update urchin outboard shield to use new zmk module repo

### DIFF
--- a/.github/workflows/outboards/shields/urchin
+++ b/.github/workflows/outboards/shields/urchin
@@ -1,7 +1,4 @@
 # Copyright 2023 Manna Harbour
 # https://github.com/manna-harbour/miryoku
 
-outboard_repository=duckyb/zmk-urchin
-outboard_ref=master
-outboard_from=config/boards/shields/urchin
-outboard_to=boards/shields/urchin
+outboard_modules=duckyb/urchin-zmk-module/main


### PR DESCRIPTION
duckyb/zmk-urchin was updated recently to use a separate zmk module repo. I updated the urchin shield to reference the appropriate module.

Tested this with my own urchin keyboard. See build: https://github.com/rkpatel7/miryoku_zmk/actions/runs/11785913200