### PR TITLE
Add support for Ergonaut One and One S

### DIFF
--- a/.github/workflows/outboards/boards/dao
+++ b/.github/workflows/outboards/boards/dao
@@ -1,7 +1,4 @@
 # Copyright 2023 Manna Harbour
 # https://github.com/manna-harbour/miryoku
 
-outboard_repository=yumagulovrn/dao-zmk-config
-outboard_ref=main
-outboard_from=config/boards/arm/dao
-outboard_to=boards/arm/dao
+outboard_modules=ergonautkb/ergonautkb-zmk-module/main

--- a/.github/workflows/outboards/shields/ergonaut_one
+++ b/.github/workflows/outboards/shields/ergonaut_one
@@ -1,0 +1,4 @@
+# Copyright 2024 Manna Harbour
+# https://github.com/manna-harbour/miryoku
+
+outboard_modules=ergonautkb/ergonautkb-zmk-module/main

--- a/.github/workflows/outboards/shields/ergonaut_one_s
+++ b/.github/workflows/outboards/shields/ergonaut_one_s
@@ -1,0 +1,4 @@
+# Copyright 2024 Manna Harbour
+# https://github.com/manna-harbour/miryoku
+
+outboard_modules=ergonautkb/ergonautkb-zmk-module/main

--- a/.github/workflows/test-all-xiao-shields.yml
+++ b/.github/workflows/test-all-xiao-shields.yml
@@ -15,6 +15,7 @@ jobs:
         "chipper_left","chipper_right",
         "clog_v2_left","clog_v2_right",
         "ergonaut_one_left","ergonaut_one_right",
+        "ergonaut_one_s_left","ergonaut_one_s_right",
         "hummingbird",
         "klein_left","klein_right",
         "kpukboard_left","kpukboard_right",

--- a/.github/workflows/test-all-xiao-shields.yml
+++ b/.github/workflows/test-all-xiao-shields.yml
@@ -14,6 +14,7 @@ jobs:
         "bad_wings",
         "chipper_left","chipper_right",
         "clog_v2_left","clog_v2_right",
+        "ergonaut_one_left","ergonaut_one_right",
         "hummingbird",
         "klein_left","klein_right",
         "kpukboard_left","kpukboard_right",

--- a/config/ergonaut_one.keymap
+++ b/config/ergonaut_one.keymap
@@ -1,0 +1,6 @@
+// Copyright 2023 Manna Harbour
+// https://github.com/manna-harbour/miryoku
+
+#include "../miryoku/custom_config.h"
+#include "../miryoku/mapping/42/corne.h"
+#include "../miryoku/miryoku.dtsi"

--- a/config/ergonaut_one_s.keymap
+++ b/config/ergonaut_one_s.keymap
@@ -1,0 +1,6 @@
+// Copyright 2023 Manna Harbour
+// https://github.com/manna-harbour/miryoku
+
+#include "../miryoku/custom_config.h"
+#include "../miryoku/mapping/36/minidox.h"
+#include "../miryoku/miryoku.dtsi"


### PR DESCRIPTION
The Ergonaut One is an easy-to-build 42-key KS-33 Xiao split, available at https://github.com/ergonautkb/one
The Ergonaut One S is an upcoming 36-key alternative with a more aggressive stagger.