### PR TITLE
Add sleep configuration for Corne with nice_view

### DIFF
--- a/.github/workflows/build-corne-nice_view-sleep.yml
+++ b/.github/workflows/build-corne-nice_view-sleep.yml
@@ -1,0 +1,14 @@
+# Custom build for Corne with nice_view and sleep enabled
+# https://github.com/manna-harbour/miryoku
+
+name: 'Build Corne nice_view with Sleep'
+on: workflow_dispatch
+jobs:
+  build:
+    uses: ./.github/workflows/main.yml
+    secrets: inherit
+    with:
+      board: '["nice_nano_v2"]'
+      shield: '["corne_left nice_view_adapter nice_view","corne_right nice_view_adapter nice_view"]'
+      alphas: '["QWERTY"]'
+      nav: '["vi"]'

--- a/config/corne.conf
+++ b/config/corne.conf
@@ -1,0 +1,11 @@
+# Power management settings for Corne (applies to both halves)
+
+# Enable deep sleep mode to save battery
+CONFIG_ZMK_SLEEP=y
+
+# Enter idle mode after 30 seconds of inactivity (default)
+CONFIG_ZMK_IDLE_TIMEOUT=30000
+
+# Enter deep sleep after 5 minutes (300000ms) of inactivity
+# Adjust as needed: 900000 = 15 min, 1800000 = 30 min
+CONFIG_ZMK_IDLE_SLEEP_TIMEOUT=300000


### PR DESCRIPTION
Enable deep sleep to fix battery drain:
- CONFIG_ZMK_SLEEP=y
- 5 minute idle sleep timeout
- Custom workflow for nice_nano_v2 + nice_view build