### PR TITLE
Pin ZMK to v0.3-branch

### DIFF
--- a/.github/workflows/build-example-corneish_zen-custom.yml
+++ b/.github/workflows/build-example-corneish_zen-custom.yml
@@ -13,4 +13,4 @@ jobs:
         "corneish_zen_v2_left","corneish_zen_v2_right"
       ]'
       kconfig: '["CONFIG_ZMK_POINTING=y\nCONFIG_ZMK_DISPLAY_HIDE_MOMENTARY_LAYERS=y\nCONFIG_CUSTOM_WIDGET_LAYER_STATUS_HIDE_HEADING=y\nCONFIG_CUSTOM_WIDGET_LOGO_IMAGE_MIRYOKU=y\nCONFIG_IL0323_INVERT=y"]'
-      branches: '["zmkfirmware/zmk/main caksoylar/zmk/caksoylar/zen-v1+v2"]'
+      branches: '["zmkfirmware/zmk/v0.3-branch caksoylar/zmk/caksoylar/zen-v1+v2"]'

--- a/.github/workflows/build-example-xmk-native_posix_64.yml
+++ b/.github/workflows/build-example-xmk-native_posix_64.yml
@@ -10,4 +10,4 @@ jobs:
     with:
       board: '["native_posix_64"]'
       custom_config: '["#define MIRYOKU_KLUDGE_TAPDELAY"]'
-      branches: '["petejohanson/zmk/shell/tap-command","zmkfirmware/zmk/main petejohanson/zmk/shell/tap-command"]'
+      branches: '["petejohanson/zmk/shell/tap-command","zmkfirmware/zmk/v0.3-branch petejohanson/zmk/shell/tap-command"]'

--- a/.github/workflows/build-example-xmk-xmk.yml
+++ b/.github/workflows/build-example-xmk-xmk.yml
@@ -10,4 +10,4 @@ jobs:
     with:
       board: '["nice_nano_v2"]'
       shield: '["xmk"]'
-      branches: '["petejohanson/zmk/shell/tap-command","zmkfirmware/zmk/main petejohanson/zmk/shell/tap-command"]'
+      branches: '["petejohanson/zmk/shell/tap-command","zmkfirmware/zmk/v0.3-branch petejohanson/zmk/shell/tap-command"]'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -238,7 +238,7 @@ jobs:
           zmk=`echo "$branches" | cut -d ' ' -f 1`
           if [ -z "$zmk" ]
           then
-            zmk='zmkfirmware/zmk/main'
+            zmk='zmkfirmware/zmk/v0.3-branch'
           fi
           user=`echo "$zmk" | cut -f 1 -d '/'`
           repo=`echo "$zmk" | cut -f 2 -d '/'`


### PR DESCRIPTION
Due to the Zephyr 4.1 update the board naming have been changed, breaking the miryoku build system.
This PR changes the default ZMK branch from `main` to `v0.3-branch`.

References
[Pin your ZMK version](https://zmk.dev/blog/2025/06/20/pinned-zmk)
[Zephyr 4.1 Board Revisions](https://zmk.dev/blog/2025/12/09/zephyr-4-1#board-revisions)